### PR TITLE
feat: add support for custom LLMs via factory abstraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,11 +174,40 @@ CogniVault supports OpenAI out of the box via a `.env` file in the root of the p
 OPENAI_API_KEY=your-key-here
 OPENAI_MODEL=gpt-4
 OPENAI_API_BASE=https://api.openai.com/v1  # Optional
+COGNIVAULT_LLM=openai  # Change to "stub" to use a mock LLM for testing
 ```
 
-These credentials are automatically loaded using `python-dotenv` via the `OpenAIConfig` class in `cognivault/config/openai_config.py`.
+You can define new LLM backends by extending the `LLMInterface` and registering them in the `LLMFactory`. The active backend is selected via the environment variable `COGNIVAULT_LLM`.
 
-You can define new LLMs or stubs and inject them by extending the `LLMInterface` contract.
+Example:
+```env
+COGNIVAULT_LLM=openai  # or "stub" for mock runs
+```
+
+The `OPENAI_*` variables below are only required when using the OpenAI backend:
+
+---
+
+## 🧩 Advanced: Adding a Custom LLM
+
+To integrate your own model (e.g. hosted model or different provider like Anthropic, Mistral, or local inference):
+
+1. **Implement the interface**:
+   Create a new class that inherits from `LLMInterface` in `src/cognivault/llm/llm_interface.py`.
+
+2. **Add to factory**:
+   Register your new implementation in `LLMFactory` (`src/cognivault/llm/factory.py`) under a new provider name.
+
+3. **Update the enum**:
+   Add your provider to `LLMProvider` in `src/cognivault/llm/provider_enum.py`.
+
+4. **Configure it**:
+   In your `.env`, set:
+   ```
+   COGNIVAULT_LLM=yourprovider
+   ```
+
+This approach allows you to cleanly swap or combine LLMs in the future with minimal change to your orchestrator or agent code.
 
 ---
 

--- a/src/cognivault/llm/factory.py
+++ b/src/cognivault/llm/factory.py
@@ -1,0 +1,28 @@
+from cognivault.llm.llm_interface import LLMInterface
+from cognivault.llm.openai import OpenAIChatLLM
+from cognivault.llm.stub import StubLLM
+from cognivault.config.openai_config import OpenAIConfig
+from cognivault.llm.provider_enum import LLMProvider
+
+import os
+from typing import Optional
+
+
+class LLMFactory:
+    @staticmethod
+    def create(llm_name: Optional[LLMProvider] = None) -> LLMInterface:
+        llm_name = llm_name or LLMProvider(
+            os.getenv("COGNIVAULT_LLM", "openai").lower()
+        )
+
+        if llm_name == LLMProvider.OPENAI:
+            config = OpenAIConfig.load()
+            return OpenAIChatLLM(
+                api_key=config.api_key,
+                model=config.model,
+                base_url=config.base_url,
+            )
+        elif llm_name == LLMProvider.STUB:
+            return StubLLM()
+        else:
+            raise ValueError(f"Unsupported LLM type: {llm_name}")

--- a/src/cognivault/llm/provider_enum.py
+++ b/src/cognivault/llm/provider_enum.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+
+class LLMProvider(str, Enum):
+    OPENAI = "openai"
+    STUB = "stub"

--- a/src/cognivault/llm/stub.py
+++ b/src/cognivault/llm/stub.py
@@ -1,9 +1,20 @@
-class StubLLM:
+from cognivault.llm.llm_interface import LLMInterface, LLMResponse
+from typing import Iterator, Optional, Callable, Any, Union
+
+
+class StubLLM(LLMInterface):
     """
     A stubbed LLM class used for testing without incurring API costs or making external calls.
     """
 
-    def generate(self, prompt: str) -> str:
+    def generate(
+        self,
+        prompt: str,
+        *,
+        stream: bool = False,
+        on_log: Optional[Callable[[str], None]] = None,
+        **kwargs: Any,
+    ) -> Union[LLMResponse, Iterator[str]]:
         """
         Generate a mock response for a given prompt. This simulates the behavior of a real LLM.
 
@@ -11,10 +22,21 @@ class StubLLM:
         ----------
         prompt : str
             The input text prompt to simulate a response for.
+        stream : bool, optional
+            If True, simulate streaming output. Ignored in this stub.
+        on_log : Callable[[str], None], optional
+            Optional logging callback for tracing messages. Ignored in this stub.
+        **kwargs : dict
+            Additional keyword arguments (ignored in this stub).
 
         Returns
         -------
-        str
-            A canned or fake response string.
+        LLMResponse
+            A canned response object.
         """
-        return f"[STUB RESPONSE] You asked: {prompt}"
+        return LLMResponse(
+            text=f"[STUB RESPONSE] You asked: {prompt}",
+            tokens_used=0,
+            model_name="stub-llm",
+            finish_reason="stop",
+        )

--- a/tests/llm/test_factory.py
+++ b/tests/llm/test_factory.py
@@ -1,0 +1,34 @@
+import os
+import pytest
+from cognivault.llm.factory import LLMFactory
+from cognivault.llm.provider_enum import LLMProvider
+from cognivault.llm.openai import OpenAIChatLLM
+from cognivault.llm.stub import StubLLM
+
+
+def test_factory_returns_openai(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("COGNIVAULT_LLM", "openai")
+
+    llm = LLMFactory.create(LLMProvider.OPENAI)
+    assert isinstance(llm, OpenAIChatLLM)
+
+
+def test_factory_returns_stub(monkeypatch):
+    monkeypatch.delenv("COGNIVAULT_LLM", raising=False)
+    llm = LLMFactory.create(LLMProvider.STUB)
+    assert isinstance(llm, StubLLM)
+
+
+def test_factory_invalid_llm_from_env(monkeypatch):
+    monkeypatch.setenv("COGNIVAULT_LLM", "banana")
+    with pytest.raises(ValueError, match="'banana' is not a valid LLMProvider"):
+        LLMFactory.create()
+
+
+def test_factory_invalid_enum_value():
+    class FakeEnum:
+        pass
+
+    with pytest.raises(ValueError, match="Unsupported LLM type: .*"):
+        LLMFactory.create(FakeEnum())

--- a/tests/llm/test_stub.py
+++ b/tests/llm/test_stub.py
@@ -1,8 +1,10 @@
 from cognivault.llm.stub import StubLLM
+from cognivault.llm.llm_interface import LLMResponse
 
 
 def test_stub_llm_generate():
     llm = StubLLM()
     prompt = "What is the capital of France?"
     response = llm.generate(prompt)
-    assert response == "[STUB RESPONSE] You asked: What is the capital of France?"
+    assert isinstance(response, LLMResponse)
+    assert response.text == "[STUB RESPONSE] You asked: What is the capital of France?"


### PR DESCRIPTION
- Introduced LLMFactory with support for OpenAI and Stub implementations
- Created LLMProvider enum for type-safe LLM selection via env or param
- Refactored orchestrator to use factory instead of hardcoding OpenAI
- Added 100% test coverage for factory and provider selection logic
- Updated README with advanced section on adding a custom LLM