### PR TITLE
RefinerAgent: Handle malformed and nonsensical queries with fallback …

### DIFF
--- a/scripts/agents/refiner/test_batch.py
+++ b/scripts/agents/refiner/test_batch.py
@@ -23,6 +23,7 @@ os.makedirs(OUTPUT_DIR, exist_ok=True)
 import asyncio
 
 TEST_QUERIES = [
+    # Regular queries (good for testing refinement)
     "AI and...",
     "democracy good?",
     "What is time?",
@@ -30,8 +31,17 @@ TEST_QUERIES = [
     "Is knowledge power?",
     "Cognition???",
     "the future of humanity?",
-    "How do?",
     "What does it all mean?",
+    # Problematic/edge case queries (testing fallback behavior)
+    "",  # Empty string
+    "???",  # Pure nonsense
+    "   ",  # Whitespace only
+    "How do?",  # Incomplete fragment
+    "...",  # Ellipsis only
+    "????",  # Multiple question marks
+    "what",  # Single word, too vague
+    "a b c",  # Random words
+    "huh?",  # Conversational interjection
 ]
 
 

--- a/src/cognivault/agents/refiner/prompts.py
+++ b/src/cognivault/agents/refiner/prompts.py
@@ -25,6 +25,11 @@ REFINER_SYSTEM_PROMPT = """You are the RefinerAgent, the first stage in a cognit
 **PASSIVE MODE** (when query is already structured):
 - Query is clear and well-structured → Return unchanged with "[Unchanged]" tag
 
+**FALLBACK MODE** (for severely malformed inputs):
+- Empty input ("", "   ") → "What topic would you like to explore or discuss?"
+- Nonsense input ("???", "How do?") → "What specific question or topic are you interested in learning about?"
+- Incomplete fragments → Transform into complete, actionable questions
+
 ## OUTPUT FORMAT
 
 Return ONLY the refined question as a single, well-structured sentence or question. Do not add explanations, commentary, or additional content beyond the clarified query.
@@ -42,6 +47,20 @@ Return ONLY the refined question as a single, well-structured sentence or questi
 
 **Input:** "How do economic policies affect income inequality in developed nations?"
 **Output:** "[Unchanged] How do economic policies affect income inequality in developed nations?"
+
+**FALLBACK EXAMPLES:**
+
+**Input:** ""
+**Output:** "What topic would you like to explore or discuss?"
+
+**Input:** "   "
+**Output:** "What topic would you like to explore or discuss?"
+
+**Input:** "???"
+**Output:** "What specific question or topic are you interested in learning about?"
+
+**Input:** "How do?"
+**Output:** "What specific question or topic are you interested in learning about?"
 
 ## CONSTRAINTS
 


### PR DESCRIPTION
# 🧪 RefinerAgent Edge Case Fallbacks

This PR enhances the resilience of the `RefinerAgent` by introducing explicit fallback behavior for malformed, vague, or nonsensical user queries. These edge cases are now gracefully handled with structured prompts that preserve user intent and ensure compatibility with downstream agents.

## ✅ Summary

- Adds **FALLBACK MODE** behavior to `REFINER_SYSTEM_PROMPT`
- Handles inputs like `""`, `"???"`, `"   "`, `"How do?"`, `"..."` with safe, meaningful defaults
- Expands `test_batch.py` with 9+ problematic queries for visual validation
- Adds dedicated unit test: `test_refiner_handles_blank_or_nonsense_query`
- Ensures consistent formatting (`Refined query:` or `[Unchanged]`) across fallback scenarios
- Improves system prompt documentation with fallback-specific examples

## 📄 Files Modified
```
scripts/agents/refiner/test_batch.py
src/cognivault/agents/refiner/prompts.py
tests/agents/refiner/test_agent.py
```

## 🔍 Motivation

While most user queries benefit from clarification, malformed or incoherent inputs can confuse the pipeline or produce unpredictable output. This update ensures:

- Output remains parseable and consistent
- Refiner doesn't stall or pass ambiguous queries to downstream agents
- Users get constructive feedback even with poorly formed prompts

It also closes the remaining task from [#14](https://github.com/aucontraire/cognivault/issues/14):  
> Add explicit tests for edge-case inputs like empty strings, nonsense, and malformed fragments

## 🧪 Test Coverage

- ✅ 100% test coverage maintained
- ✅ All fallback modes verified through new test and batch review
- ✅ System prompt logic validated in `test_refiner_agent_adds_output` and `test_refiner_agent_unchanged_query`

## 📦 Versioning Context

Follows [v0.8.0-alpha.1](https://github.com/aucontraire/cognivault/releases/tag/v0.8.0-alpha.1), which introduced the RefinerAgent system prompt and CLI test harness.

This PR may inform a future `v0.8.0-alpha.2` tag for edge-case coverage and system robustness.

## 🔗 Related Issues

Closes #14  
Part of #Agent Spec & Prompt Design Pass  
Builds on:  
- #13 Design RefinerAgent System Prompt  
- #12 Define Charter for RefinerAgent  

## 🏷 Suggested Labels

`agent-spec`, `refiner`, `output-format`, `fallback`, `v0.8.0`