### PR TITLE
Add make run-safe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install test run lint format clean coverage-all coverage coverage-one test-agent-% run-agent-cli-%
+.PHONY: install test run run-safe lint format clean coverage-all coverage coverage-one test-agent-% run-agent-cli-%
 
 install:
 	bash scripts/setup.sh
@@ -21,6 +21,11 @@ run:
 	$(if $(ROLLBACK_LAST_CHECKPOINT),--rollback-last-checkpoint,) \
 	$(if $(COMPARE_MODES),--compare-modes,) \
 	$(if $(BENCHMARK_RUNS),--benchmark-runs=$(BENCHMARK_RUNS),)
+
+run-safe:
+	$(MAKE) check
+	$(MAKE) test
+	$(MAKE) run
 
 lint:
 	poetry run ruff check src/ tests/

--- a/README.md
+++ b/README.md
@@ -959,11 +959,29 @@ This approach allows you to cleanly swap or combine LLMs in the future with mini
 
 Make sure your `.env` file is configured with your OpenAI credentials if using the OpenAI LLM backend.
 
+#### Quick Execution
+
 To run the full pipeline with all agents:
 
 ```bash
 make run QUESTION="Is democracy becoming more robust globally?"
 ```
+
+#### Safe Execution with Validation
+
+For production-ready execution with type checking, formatting, and test validation:
+
+```bash
+make run-safe QUESTION="Is democracy becoming more robust globally?"
+```
+
+The `run-safe` target provides **"compilation-like" safety** for Python by running:
+1. **Format checking** (`black` + `ruff`) 
+2. **Type checking** (`mypy`)
+3. **Test validation** (all tests must pass)
+4. **Application execution** (your query)
+
+This is recommended for CI/CD pipelines and when you want to ensure code quality before execution. All the same arguments work with `run-safe` as with `run`.
 
 This executes:
 


### PR DESCRIPTION
 The run-safe target passes through all the same arguments that make run accepts because it ultimately calls $(MAKE) run at the end.

  ✅ All these work exactly the same:

  # Basic execution
  make run-safe QUESTION="What is machine learning?"

  # With specific agents
  make run-safe QUESTION="Analyze this data" AGENTS=refiner,critic

  # With debug logging  
  make run-safe QUESTION="Your question" LOG_LEVEL=DEBUG

  # Export markdown
  make run-safe QUESTION="Your question" EXPORT_MD=1

  # With checkpoints enabled
  make run-safe QUESTION="Your question" ENABLE_CHECKPOINTS=1

  # Compare execution modes
  make run-safe QUESTION="Your question" COMPARE_MODES=1

  # All the advanced options work too:
  make run-safe QUESTION="Your question" TRACE=1 HEALTH_CHECK=1 DRY_RUN=1
