### PR TITLE
fix(store): extract rich metadata from structured outputs for frontmatter

### DIFF
--- a/src/cognivault/store/wiki_adapter.py
+++ b/src/cognivault/store/wiki_adapter.py
@@ -14,6 +14,19 @@ from .frontmatter import (
 )
 from cognivault.config.app_config import get_config
 
+# Import structured output models for metadata extraction
+try:
+    from cognivault.agents.models import (
+        RefinerOutput,
+        CriticOutput,
+        HistorianOutput,
+        SynthesisOutput,
+        BaseAgentOutput,
+    )
+    STRUCTURED_OUTPUTS_AVAILABLE = True
+except ImportError:
+    STRUCTURED_OUTPUTS_AVAILABLE = False
+
 
 class MarkdownExporter:
     """
@@ -163,6 +176,238 @@ class MarkdownExporter:
 
         return filepath
 
+    @staticmethod
+    def _extract_metadata_from_structured_output(
+        agent_name: str, output: Any
+    ) -> AgentExecutionResult:
+        """
+        Extract metadata from structured agent outputs.
+
+        Handles both Pydantic models and dict representations.
+        Falls back to defaults if structured output is not available.
+
+        Parameters
+        ----------
+        agent_name : str
+            Name of the agent.
+        output : Any
+            Agent output (Pydantic model, dict, or string).
+
+        Returns
+        -------
+        AgentExecutionResult
+            Extracted metadata with confidence, processing time, and agent-specific fields.
+        """
+        # Default values
+        metadata: Dict[str, Any] = {}
+        confidence = 0.8
+        processing_time_ms = None
+        status = AgentStatus.INTEGRATED
+        changes_made = True
+
+        # Handle Pydantic model instances
+        if STRUCTURED_OUTPUTS_AVAILABLE and isinstance(output, BaseAgentOutput):
+            # Extract common fields
+            confidence_map = {"high": 0.9, "medium": 0.7, "low": 0.5}
+            confidence = confidence_map.get(
+                output.confidence.lower() if hasattr(output, "confidence") else "medium",
+                0.7,
+            )
+            processing_time_ms = getattr(output, "processing_time_ms", None)
+
+            # Extract agent-specific metadata
+            if isinstance(output, RefinerOutput):
+                status = (
+                    AgentStatus.PASSTHROUGH
+                    if output.was_unchanged
+                    else AgentStatus.REFINED
+                )
+                changes_made = not output.was_unchanged
+                metadata.update(
+                    {
+                        "changes_made_count": len(output.changes_made),
+                        "ambiguities_resolved": len(output.ambiguities_resolved),
+                        "fallback_used": output.fallback_used,
+                    }
+                )
+            elif isinstance(output, CriticOutput):
+                status = (
+                    AgentStatus.INSUFFICIENT_CONTENT
+                    if output.no_issues_found
+                    else AgentStatus.ANALYZED
+                )
+                changes_made = output.issues_detected > 0
+                metadata.update(
+                    {
+                        "issues_detected": output.issues_detected,
+                        "biases_found": len(output.biases),
+                        "no_issues_found": output.no_issues_found,
+                    }
+                )
+            elif isinstance(output, HistorianOutput):
+                status = (
+                    AgentStatus.NO_MATCHES
+                    if output.no_relevant_context
+                    else AgentStatus.FOUND_MATCHES
+                )
+                changes_made = output.relevant_sources_found > 0
+                metadata.update(
+                    {
+                        "sources_searched": output.sources_searched,
+                        "relevant_sources_found": output.relevant_sources_found,
+                        "themes_identified": len(output.themes_identified),
+                    }
+                )
+            elif isinstance(output, SynthesisOutput):
+                status = AgentStatus.INTEGRATED
+                changes_made = True
+                metadata.update(
+                    {
+                        "themes_count": len(output.key_themes),
+                        "contributing_agents": len(output.contributing_agents),
+                        "word_count": output.word_count,
+                    }
+                )
+
+        # Handle dict representations (from model_dump())
+        elif isinstance(output, dict):
+            # Try to extract common fields
+            if "confidence" in output:
+                confidence_value = output["confidence"]
+                if isinstance(confidence_value, str):
+                    confidence_map = {"high": 0.9, "medium": 0.7, "low": 0.5}
+                    confidence = confidence_map.get(confidence_value.lower(), 0.7)
+                else:
+                    confidence = float(confidence_value)
+
+            processing_time_ms = output.get("processing_time_ms")
+
+            # Extract agent-specific metadata based on known fields
+            if "was_unchanged" in output:  # RefinerOutput
+                status = (
+                    AgentStatus.PASSTHROUGH
+                    if output["was_unchanged"]
+                    else AgentStatus.REFINED
+                )
+                changes_made = not output["was_unchanged"]
+                metadata.update(
+                    {
+                        "changes_made_count": len(output.get("changes_made", [])),
+                        "ambiguities_resolved": len(
+                            output.get("ambiguities_resolved", [])
+                        ),
+                        "fallback_used": output.get("fallback_used", False),
+                    }
+                )
+            elif "issues_detected" in output:  # CriticOutput
+                no_issues = output.get("no_issues_found", False)
+                status = (
+                    AgentStatus.INSUFFICIENT_CONTENT
+                    if no_issues
+                    else AgentStatus.ANALYZED
+                )
+                changes_made = output["issues_detected"] > 0
+                metadata.update(
+                    {
+                        "issues_detected": output["issues_detected"],
+                        "biases_found": len(output.get("biases", [])),
+                        "no_issues_found": no_issues,
+                    }
+                )
+            elif "sources_searched" in output:  # HistorianOutput
+                no_context = output.get("no_relevant_context", False)
+                status = AgentStatus.NO_MATCHES if no_context else AgentStatus.FOUND_MATCHES
+                changes_made = output.get("relevant_sources_found", 0) > 0
+                metadata.update(
+                    {
+                        "sources_searched": output["sources_searched"],
+                        "relevant_sources_found": output.get("relevant_sources_found", 0),
+                        "themes_identified": len(output.get("themes_identified", [])),
+                    }
+                )
+            elif "key_themes" in output or "contributing_agents" in output:  # SynthesisOutput
+                status = AgentStatus.INTEGRATED
+                changes_made = True
+                metadata.update(
+                    {
+                        "themes_count": len(output.get("key_themes", [])),
+                        "contributing_agents": len(output.get("contributing_agents", [])),
+                        "word_count": output.get("word_count", 0),
+                    }
+                )
+
+        return AgentExecutionResult(
+            status=status,
+            confidence=confidence,
+            processing_time_ms=int(processing_time_ms) if processing_time_ms else None,
+            changes_made=changes_made,
+            metadata=metadata,
+        )
+
+    @staticmethod
+    def _generate_summary_from_outputs(
+        question: str, agent_outputs: Dict[str, Any]
+    ) -> str:
+        """
+        Generate an intelligent summary from agent outputs.
+
+        Extracts key insights from RefinerOutput.refined_query and
+        SynthesisOutput.final_synthesis instead of using hardcoded dummy text.
+
+        Parameters
+        ----------
+        question : str
+            Original question.
+        agent_outputs : Dict[str, Any]
+            Agent outputs (can be strings, dicts, or Pydantic models).
+
+        Returns
+        -------
+        str
+            Generated summary of the interaction.
+        """
+        summary_parts = []
+
+        # Try to extract refined query from RefinerOutput
+        refiner_output = agent_outputs.get("refiner")
+        if refiner_output:
+            if STRUCTURED_OUTPUTS_AVAILABLE and isinstance(refiner_output, RefinerOutput):
+                refined_query = refiner_output.refined_query
+                summary_parts.append(f"Refined query: {refined_query[:100]}...")
+            elif isinstance(refiner_output, dict) and "refined_query" in refiner_output:
+                refined_query = refiner_output["refined_query"]
+                summary_parts.append(f"Refined query: {refined_query[:100]}...")
+
+        # Try to extract synthesis from SynthesisOutput
+        synthesis_output = agent_outputs.get("synthesis")
+        if synthesis_output:
+            if STRUCTURED_OUTPUTS_AVAILABLE and isinstance(synthesis_output, SynthesisOutput):
+                synthesis_text = synthesis_output.final_synthesis
+                # Extract first sentence or first 150 chars
+                first_sentence = synthesis_text.split(".")[0] + "."
+                summary_parts.append(
+                    first_sentence
+                    if len(first_sentence) < 150
+                    else synthesis_text[:150] + "..."
+                )
+            elif isinstance(synthesis_output, dict) and "final_synthesis" in synthesis_output:
+                synthesis_text = synthesis_output["final_synthesis"]
+                first_sentence = synthesis_text.split(".")[0] + "."
+                summary_parts.append(
+                    first_sentence
+                    if len(first_sentence) < 150
+                    else synthesis_text[:150] + "..."
+                )
+
+        # Fallback to generic summary if no structured outputs available
+        if not summary_parts:
+            agent_names = ", ".join(agent_outputs.keys())
+            summary_parts.append(
+                f"Multi-agent analysis from {agent_names} addressing: {question[:80]}..."
+            )
+
+        return " ".join(summary_parts)
+
     def _build_enhanced_frontmatter(
         self,
         question: str,
@@ -177,21 +422,22 @@ class MarkdownExporter:
     ) -> EnhancedFrontmatter:
         """Build enhanced frontmatter with comprehensive metadata."""
 
-        # Create base frontmatter
+        # Generate intelligent summary from agent outputs
+        summary = self._generate_summary_from_outputs(question, agent_outputs)
+
+        # Create base frontmatter with generated summary
         frontmatter = EnhancedFrontmatter(
-            title=question, date=timestamp, filename=filename, source="cli"
+            title=question, date=timestamp, filename=filename, source="cli", summary=summary
         )
 
-        # Add agent results or create defaults
+        # Add agent results - extract from structured outputs if not provided
         if agent_results:
             for agent_name, result in agent_results.items():
                 frontmatter.add_agent_result(agent_name, result)
         else:
-            # Create default results for backward compatibility
-            for agent_name in agent_outputs.keys():
-                result = AgentExecutionResult(
-                    status=AgentStatus.INTEGRATED, confidence=0.8, changes_made=True
-                )
+            # Extract metadata from structured agent outputs
+            for agent_name, output in agent_outputs.items():
+                result = self._extract_metadata_from_structured_output(agent_name, output)
                 frontmatter.add_agent_result(agent_name, result)
 
         # Add topics and domain

--- a/tests/unit/store/test_frontmatter_metadata.py
+++ b/tests/unit/store/test_frontmatter_metadata.py
@@ -1,0 +1,436 @@
+"""
+Unit tests for frontmatter metadata extraction and summary generation.
+
+Tests verify that:
+1. Metadata is correctly extracted from structured agent outputs
+2. Summaries are intelligently generated from agent content
+3. Backward compatibility is maintained for string outputs
+4. Agent-specific metadata fields are properly captured
+"""
+
+import pytest
+from typing import Dict, Any
+from cognivault.store.wiki_adapter import MarkdownExporter
+from cognivault.store.frontmatter import AgentExecutionResult, AgentStatus
+from cognivault.agents.models import (
+    RefinerOutput,
+    CriticOutput,
+    HistorianOutput,
+    SynthesisOutput,
+    ConfidenceLevel,
+    BiasType,
+    BiasDetail,
+    ProcessingMode,
+    HistoricalReference,
+    SynthesisTheme,
+)
+
+
+class TestMetadataExtraction:
+    """Test metadata extraction from structured outputs."""
+
+    def test_extract_metadata_from_refiner_output(self) -> None:
+        """Test extracting metadata from RefinerOutput model."""
+        output = RefinerOutput(
+            agent_name="refiner",
+            processing_mode=ProcessingMode.ACTIVE,
+            confidence=ConfidenceLevel.HIGH,
+            processing_time_ms=150.0,
+            refined_query="What are the implications of AI on society?",
+            original_query="AI and society",
+            changes_made=["Added scope", "Clarified intent"],
+            was_unchanged=False,
+            ambiguities_resolved=["Unclear scope"],
+        )
+
+        result = MarkdownExporter._extract_metadata_from_structured_output("refiner", output)
+
+        assert result.status == AgentStatus.REFINED
+        assert result.confidence == 0.9  # HIGH = 0.9
+        assert result.processing_time_ms == 150
+        assert result.changes_made is True
+        assert result.metadata["changes_made_count"] == 2
+        assert result.metadata["ambiguities_resolved"] == 1
+        assert result.metadata["fallback_used"] is False
+
+    def test_extract_metadata_from_refiner_passthrough(self) -> None:
+        """Test extracting metadata when refiner passes through unchanged."""
+        output = RefinerOutput(
+            agent_name="refiner",
+            processing_mode=ProcessingMode.PASSIVE,
+            confidence=ConfidenceLevel.HIGH,
+            refined_query="Perfect query unchanged",
+            original_query="Perfect query unchanged",
+            was_unchanged=True,
+        )
+
+        result = MarkdownExporter._extract_metadata_from_structured_output("refiner", output)
+
+        assert result.status == AgentStatus.PASSTHROUGH
+        assert result.changes_made is False
+        assert result.metadata["changes_made_count"] == 0
+
+    def test_extract_metadata_from_critic_output(self) -> None:
+        """Test extracting metadata from CriticOutput model."""
+        output = CriticOutput(
+            agent_name="critic",
+            processing_mode=ProcessingMode.ACTIVE,
+            confidence=ConfidenceLevel.MEDIUM,
+            processing_time_ms=200.0,
+            assumptions=["Assumes AI is beneficial"],
+            logical_gaps=["Missing definition of society"],
+            biases=[BiasType.TEMPORAL, BiasType.CONFIRMATION],
+            bias_details=[
+                BiasDetail(
+                    bias_type=BiasType.TEMPORAL,
+                    explanation="Focuses on current AI without historical context"
+                )
+            ],
+            alternate_framings=["Consider historical precedents"],
+            critique_summary="Query lacks scope and definition",
+            issues_detected=5,
+            no_issues_found=False,
+        )
+
+        result = MarkdownExporter._extract_metadata_from_structured_output("critic", output)
+
+        assert result.status == AgentStatus.ANALYZED
+        assert result.confidence == 0.7  # MEDIUM = 0.7
+        assert result.processing_time_ms == 200
+        assert result.changes_made is True
+        assert result.metadata["issues_detected"] == 5
+        assert result.metadata["biases_found"] == 2
+        assert result.metadata["no_issues_found"] is False
+
+    def test_extract_metadata_from_critic_no_issues(self) -> None:
+        """Test extracting metadata when critic finds no issues."""
+        output = CriticOutput(
+            agent_name="critic",
+            processing_mode=ProcessingMode.ACTIVE,
+            confidence=ConfidenceLevel.HIGH,
+            critique_summary="Query is well-scoped and neutral",
+            issues_detected=0,
+            no_issues_found=True,
+        )
+
+        result = MarkdownExporter._extract_metadata_from_structured_output("critic", output)
+
+        assert result.status == AgentStatus.INSUFFICIENT_CONTENT
+        assert result.changes_made is False
+        assert result.metadata["no_issues_found"] is True
+
+    def test_extract_metadata_from_historian_output(self) -> None:
+        """Test extracting metadata from HistorianOutput model."""
+        output = HistorianOutput(
+            agent_name="historian",
+            processing_mode=ProcessingMode.ACTIVE,
+            confidence=ConfidenceLevel.HIGH,
+            processing_time_ms=500.0,
+            relevant_sources=[
+                HistoricalReference(
+                    source_id="doc1",
+                    title="AI History",
+                    relevance_score=0.9,
+                    content_snippet="Historical context about AI..."
+                )
+            ],
+            historical_synthesis="Historical analysis of AI development shows patterns of adoption and resistance across multiple decades, reflecting broader societal transformations.",
+            themes_identified=["Technology adoption", "Social resistance"],
+            time_periods_covered=["1950s-2020s"],
+            contextual_connections=["Similar to industrial revolution patterns"],
+            sources_searched=10,
+            relevant_sources_found=1,  # Must match len(relevant_sources)
+            no_relevant_context=False,
+        )
+
+        result = MarkdownExporter._extract_metadata_from_structured_output("historian", output)
+
+        assert result.status == AgentStatus.FOUND_MATCHES
+        assert result.confidence == 0.9  # HIGH = 0.9
+        assert result.processing_time_ms == 500
+        assert result.changes_made is True
+        assert result.metadata["sources_searched"] == 10
+        assert result.metadata["relevant_sources_found"] == 1  # Matches len(relevant_sources)
+        assert result.metadata["themes_identified"] == 2
+
+    def test_extract_metadata_from_historian_no_matches(self) -> None:
+        """Test extracting metadata when historian finds no relevant context."""
+        output = HistorianOutput(
+            agent_name="historian",
+            processing_mode=ProcessingMode.ACTIVE,
+            confidence=ConfidenceLevel.LOW,
+            historical_synthesis="No relevant historical context found for this query.",
+            sources_searched=5,
+            relevant_sources_found=0,
+            no_relevant_context=True,
+        )
+
+        result = MarkdownExporter._extract_metadata_from_structured_output("historian", output)
+
+        assert result.status == AgentStatus.NO_MATCHES
+        assert result.changes_made is False
+
+    def test_extract_metadata_from_synthesis_output(self) -> None:
+        """Test extracting metadata from SynthesisOutput model."""
+        synthesis_text = "Comprehensive synthesis of all agent outputs demonstrating deep analysis and integration of perspectives across multiple dimensions of the question exploring various facets and angles considering historical context contemporary developments future implications theoretical frameworks practical applications empirical evidence scholarly consensus divergent viewpoints methodological approaches analytical techniques interpretive strategies and synthesis methodologies."
+        output = SynthesisOutput(
+            agent_name="synthesis",
+            processing_mode=ProcessingMode.ACTIVE,
+            confidence=ConfidenceLevel.HIGH,
+            processing_time_ms=300.0,
+            final_synthesis=synthesis_text,
+            key_themes=[
+                SynthesisTheme(
+                    theme_name="AI Impact",
+                    description="Analysis of AI societal impact",
+                    supporting_agents=["refiner", "critic", "historian"],
+                    confidence=ConfidenceLevel.HIGH,
+                )
+            ],
+            contributing_agents=["refiner", "critic", "historian"],
+            word_count=len(synthesis_text.split()),
+        )
+
+        result = MarkdownExporter._extract_metadata_from_structured_output("synthesis", output)
+
+        assert result.status == AgentStatus.INTEGRATED
+        assert result.confidence == 0.9  # HIGH = 0.9
+        assert result.processing_time_ms == 300
+        assert result.changes_made is True
+        assert result.metadata["themes_count"] == 1
+        assert result.metadata["contributing_agents"] == 3
+        assert result.metadata["word_count"] > 0
+
+    def test_extract_metadata_from_dict_representation(self) -> None:
+        """Test extracting metadata from dict (model_dump()) representations."""
+        output_dict = {
+            "agent_name": "refiner",
+            "processing_mode": "active",
+            "confidence": "high",
+            "processing_time_ms": 150.0,
+            "refined_query": "What are the implications?",
+            "original_query": "AI",
+            "changes_made": ["Added clarity"],
+            "was_unchanged": False,
+            "ambiguities_resolved": ["Scope"],
+            "fallback_used": False,
+        }
+
+        result = MarkdownExporter._extract_metadata_from_structured_output("refiner", output_dict)
+
+        assert result.status == AgentStatus.REFINED
+        assert result.confidence == 0.9
+        assert result.processing_time_ms == 150
+        assert result.metadata["changes_made_count"] == 1
+
+    def test_extract_metadata_from_string_output(self) -> None:
+        """Test extracting metadata from legacy string outputs (backward compatibility)."""
+        output = "This is a legacy string output from an agent."
+
+        result = MarkdownExporter._extract_metadata_from_structured_output("legacy_agent", output)
+
+        # Should fall back to defaults
+        assert result.status == AgentStatus.INTEGRATED
+        assert result.confidence == 0.8
+        assert result.processing_time_ms is None
+        assert result.changes_made is True
+        assert result.metadata == {}
+
+    def test_extract_metadata_handles_missing_processing_time(self) -> None:
+        """Test that missing processing_time_ms is handled gracefully."""
+        output = RefinerOutput(
+            agent_name="refiner",
+            processing_mode=ProcessingMode.ACTIVE,
+            confidence=ConfidenceLevel.MEDIUM,
+            refined_query="Test query",
+            original_query="Test",
+            # processing_time_ms intentionally omitted
+        )
+
+        result = MarkdownExporter._extract_metadata_from_structured_output("refiner", output)
+
+        assert result.processing_time_ms is None  # Should handle gracefully
+
+
+class TestSummaryGeneration:
+    """Test intelligent summary generation from agent outputs."""
+
+    def test_generate_summary_from_refiner_and_synthesis(self) -> None:
+        """Test generating summary from both refiner and synthesis outputs."""
+        synthesis_text = "Artificial intelligence represents a transformative technology with profound implications for human society across multiple dimensions. Research shows mixed impacts on employment patterns governance structures and social cohesion mechanisms raising complex questions about future trajectories technological adaptation cultural transformation economic disruption political governance ethical considerations regulatory frameworks societal resilience human capabilities workforce transitions educational requirements skill development community engagement democratic participation institutional adaptation organizational transformation innovation ecosystems technological infrastructure digital literacy global cooperation international collaboration cross-cultural understanding inclusive development sustainable progress."
+        agent_outputs = {
+            "refiner": RefinerOutput(
+                agent_name="refiner",
+                processing_mode=ProcessingMode.ACTIVE,
+                confidence=ConfidenceLevel.HIGH,
+                refined_query="What are the long-term implications of artificial intelligence on societal structures?",
+                original_query="AI and society",
+            ),
+            "synthesis": SynthesisOutput(
+                agent_name="synthesis",
+                processing_mode=ProcessingMode.ACTIVE,
+                confidence=ConfidenceLevel.HIGH,
+                final_synthesis=synthesis_text,
+                key_themes=[],
+                contributing_agents=["refiner", "critic", "historian"],
+                word_count=len(synthesis_text.split()),
+            ),
+        }
+
+        summary = MarkdownExporter._generate_summary_from_outputs("AI and society", agent_outputs)
+
+        assert "Refined query:" in summary
+        assert "What are the long-term implications" in summary
+        assert "Artificial intelligence represents a transformative technology" in summary
+
+    def test_generate_summary_from_dict_outputs(self) -> None:
+        """Test generating summary from dict representations."""
+        agent_outputs = {
+            "refiner": {
+                "refined_query": "How does climate change affect biodiversity in marine ecosystems?",
+                "original_query": "climate change and fish",
+            },
+            "synthesis": {
+                "final_synthesis": "Climate change poses significant threats to marine biodiversity through ocean acidification and temperature changes. Multiple species face extinction risks.",
+            },
+        }
+
+        summary = MarkdownExporter._generate_summary_from_outputs("climate", agent_outputs)
+
+        assert "Refined query:" in summary
+        assert "climate change affect biodiversity" in summary
+        assert "Climate change poses significant threats" in summary
+
+    def test_generate_summary_fallback_without_structured_outputs(self) -> None:
+        """Test summary generation falls back gracefully for non-structured outputs."""
+        agent_outputs = {
+            "agent1": "String output from agent 1",
+            "agent2": "String output from agent 2",
+        }
+
+        summary = MarkdownExporter._generate_summary_from_outputs(
+            "Test question", agent_outputs
+        )
+
+        assert "Multi-agent analysis from agent1, agent2" in summary
+        assert "Test question" in summary
+
+    def test_generate_summary_truncates_long_refined_query(self) -> None:
+        """Test that long refined queries are truncated appropriately."""
+        long_query = "A" * 200  # 200 character query
+        agent_outputs = {
+            "refiner": {"refined_query": long_query},
+        }
+
+        summary = MarkdownExporter._generate_summary_from_outputs("test", agent_outputs)
+
+        assert len(summary) < len(long_query) + 50  # Summary should be shorter
+        assert "..." in summary  # Truncation indicator
+
+    def test_generate_summary_extracts_first_sentence_from_synthesis(self) -> None:
+        """Test that only first sentence is extracted from long synthesis."""
+        agent_outputs = {
+            "synthesis": {
+                "final_synthesis": "This is the first sentence. This is a second sentence that should not be included in summary. Third sentence here."
+            },
+        }
+
+        summary = MarkdownExporter._generate_summary_from_outputs("test", agent_outputs)
+
+        assert "This is the first sentence." in summary
+        assert "second sentence" not in summary
+
+
+class TestBackwardCompatibility:
+    """Test backward compatibility with existing code."""
+
+    def test_exporter_handles_mixed_output_types(self, tmp_path) -> None:
+        """Test that exporter handles mix of string and structured outputs."""
+        exporter = MarkdownExporter(output_dir=str(tmp_path))
+
+        agent_outputs = {
+            "refiner": RefinerOutput(
+                agent_name="refiner",
+                processing_mode=ProcessingMode.ACTIVE,
+                confidence=ConfidenceLevel.HIGH,
+                refined_query="Structured output",
+                original_query="Test",
+            ),
+            "legacy_agent": "String output for backward compatibility",
+        }
+
+        filepath = exporter.export(agent_outputs=agent_outputs, question="Test question")
+
+        # Verify file was created
+        assert tmp_path / filepath.split("/")[-1]
+        with open(filepath, "r") as f:
+            content = f.read()
+            assert "refiner" in content
+            assert "legacy_agent" in content
+
+    def test_metadata_extraction_preserves_default_behavior_for_strings(self) -> None:
+        """Test that default metadata behavior is preserved for string outputs."""
+        string_output = "Legacy string output"
+        result = MarkdownExporter._extract_metadata_from_structured_output(
+            "legacy", string_output
+        )
+
+        # Should match old default behavior
+        assert result.status == AgentStatus.INTEGRATED
+        assert result.confidence == 0.8
+        assert result.changes_made is True
+
+
+class TestIntegrationWithEnhancedFrontmatter:
+    """Test integration with the enhanced frontmatter system."""
+
+    def test_build_frontmatter_uses_extracted_metadata(self, tmp_path) -> None:
+        """Test that _build_enhanced_frontmatter uses extracted metadata."""
+        exporter = MarkdownExporter(output_dir=str(tmp_path))
+
+        agent_outputs = {
+            "refiner": RefinerOutput(
+                agent_name="refiner",
+                processing_mode=ProcessingMode.ACTIVE,
+                confidence=ConfidenceLevel.HIGH,
+                processing_time_ms=150.0,
+                refined_query="Refined query",
+                original_query="Original",
+                changes_made=["Change 1"],
+            ),
+        }
+
+        frontmatter = exporter._build_enhanced_frontmatter(
+            question="Test question",
+            agent_outputs=agent_outputs,
+            timestamp="2025-12-01T00:00:00",
+            filename="test.md",
+        )
+
+        # Verify metadata was extracted correctly
+        assert "refiner" in frontmatter.agents
+        refiner_result = frontmatter.agents["refiner"]
+        assert refiner_result.status == AgentStatus.REFINED
+        assert refiner_result.confidence == 0.9
+        assert refiner_result.processing_time_ms == 150
+
+    def test_build_frontmatter_uses_generated_summary(self, tmp_path) -> None:
+        """Test that _build_enhanced_frontmatter uses generated summary."""
+        exporter = MarkdownExporter(output_dir=str(tmp_path))
+
+        agent_outputs = {
+            "synthesis": {
+                "final_synthesis": "This is an intelligent summary generated from the synthesis output."
+            },
+        }
+
+        frontmatter = exporter._build_enhanced_frontmatter(
+            question="Test question",
+            agent_outputs=agent_outputs,
+            timestamp="2025-12-01T00:00:00",
+            filename="test.md",
+        )
+
+        # Verify summary was generated intelligently
+        assert frontmatter.summary != "Generated response from CogniVault agents"  # Not default
+        assert "intelligent summary" in frontmatter.summary


### PR DESCRIPTION
Resolves data loss bug where frontmatter showed empty metadata and generic summaries despite structured outputs containing rich agent metadata.

Changes:
- Add _extract_metadata_from_structured_output() to wiki_adapter.py
  - Extracts processing_time_ms, confidence, agent-specific fields
  - Handles Pydantic models and dict representations
  - Falls back gracefully for legacy string outputs
- Add _generate_summary_from_outputs() for intelligent summaries
  - Uses RefinerOutput.refined_query (first 100 chars)
  - Falls back to SynthesisOutput.final_synthesis (first sentence)
- Update _build_enhanced_frontmatter() to use extracted metadata

Includes 19 unit tests covering all agent types and edge cases.