### PR TITLE
Class-conflict CI guardrail + v0.10.0 (roadmap 1.1)

### DIFF
--- a/.github/workflows/class-conflicts.yml
+++ b/.github/workflows/class-conflicts.yml
@@ -1,0 +1,21 @@
+name: Class Conflicts
+
+# Ratchet against duplicate class names in the production namespace (src/). Test
+# scaffolding legitimately reuses names, so this check scans src/ only. See
+# scripts/check_class_conflicts.py.
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Check for src-vs-src class-name collisions
+        run: python scripts/check_class_conflicts.py

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install test run run-safe lint format typecheck typecheck-strict typecheck-tests typecheck-tests-strict check check-strict clean coverage-all coverage coverage-one test-agent-% run-agent-cli-% db-setup db-create db-drop db-reset db-status db-check-deps db-explore db-test-start db-test-stop db-test-status db-test-setup test-integration test-pydantic-ai
+.PHONY: install test run run-safe lint format typecheck typecheck-strict typecheck-tests typecheck-tests-strict check check-strict check-class-conflicts clean coverage-all coverage coverage-one test-agent-% run-agent-cli-% db-setup db-create db-drop db-reset db-status db-check-deps db-explore db-test-start db-test-stop db-test-status db-test-setup test-integration test-pydantic-ai
 
 # Test database host port (override: `make db-test-setup POSTGRES_TEST_PORT=5450`).
 # Must match POSTGRES_TEST_PORT used by docker-compose.dev.yml.
@@ -53,6 +53,10 @@ typecheck-tests-strict:
 check:
 	$(MAKE) format
 	$(MAKE) typecheck
+	$(MAKE) check-class-conflicts
+
+check-class-conflicts:
+	python scripts/check_class_conflicts.py
 
 check-strict:
 	$(MAKE) format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognivault"
-version = "0.9.2"
+version = "0.10.0"
 description = "A composable DAG orchestration platform for multi-agent systems with declarative workflows, advanced node types, and intelligent routing"
 authors = ["aucontraire"]
 license = "AGPL-3.0"

--- a/scripts/check_class_conflicts.py
+++ b/scripts/check_class_conflicts.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""CI guardrail: fail when a class name is defined in two or more files under ``src/``.
+
+Why src-only? Test scaffolding legitimately reuses class names across modules — per-module
+pytest test-cases (``TestModel``, ``TestIntegration``) and mocks/fakes (``MockAgent``,
+``MockLLM``) are independent by design and never clash at runtime. Defensive import-fallback
+stubs (e.g. ``PackageNotFoundError``) also reuse a name across src and tests. None of these
+is a real conflict. This check therefore scans ONLY ``src/`` and fails only on a genuine
+production-namespace collision.
+
+As of the 1.1 cleanup that count is 0 (the agent-output Pydantic/TypedDict collision was
+resolved: ``RefinerOutput`` etc. are Pydantic models, ``RefinerState`` etc. are the TypedDict
+state schemas). So this is a **ratchet against regressions**, not a cleanup tool.
+
+Self-contained: standard library only, no dependency on the (untracked) ``.claude/`` registry
+tooling, so it runs anywhere — CI, pre-commit, or ``make check-class-conflicts``.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import sys
+from collections import defaultdict
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_SRC = os.path.normpath(os.path.join(_HERE, "..", "src"))
+
+
+def _scan(root: str) -> dict[str, set[str]]:
+    """Map each class name to the set of files under ``root`` that define it."""
+    found: dict[str, set[str]] = defaultdict(set)
+    for dirpath, _dirs, files in os.walk(root):
+        if "__pycache__" in dirpath:
+            continue
+        for name in files:
+            if not name.endswith(".py"):
+                continue
+            path = os.path.join(dirpath, name)
+            try:
+                tree = ast.parse(open(path, encoding="utf-8").read())
+            except (SyntaxError, UnicodeDecodeError):
+                continue
+            for node in ast.walk(tree):
+                if isinstance(node, ast.ClassDef):
+                    found[node.name].add(os.path.relpath(path))
+    return found
+
+
+def main() -> int:
+    classes = _scan(_SRC)
+    total = sum(len(v) for v in classes.values())
+    collisions = {
+        name: sorted(files) for name, files in classes.items() if len(files) > 1
+    }
+
+    if collisions:
+        print(
+            f"❌ {len(collisions)} src-vs-src class-name collision(s) (of {total} classes):"
+        )
+        for name, files in sorted(collisions.items()):
+            print(f"   {name}:")
+            for f in files:
+                print(f"       {f}")
+        print(
+            "\nEach production class name must be unique. Rename one side "
+            "(see .claude/CLASS_RENAMING_STRATEGY.md), e.g. a domain prefix or a "
+            "context suffix."
+        )
+        return 1
+
+    print(f"✅ src namespace clean: {total} classes, all names unique.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/performance/test_systemic_performance_regression.py
+++ b/tests/performance/test_systemic_performance_regression.py
@@ -36,7 +36,7 @@ from cognivault.observability import get_logger
 logger = get_logger("performance.systemic_regression")
 
 
-class PerformanceProfiler:
+class ProfilingContext:
     """Context manager for detailed performance profiling."""
 
     def __init__(self, operation_name: str):
@@ -48,7 +48,7 @@ class PerformanceProfiler:
         self.memory_start: Optional[Any] = None
         self.memory_end: Optional[Any] = None
 
-    def __enter__(self) -> "PerformanceProfiler":
+    def __enter__(self) -> "ProfilingContext":
         self.start_time = time.time()
         self.cpu_percent_start = psutil.cpu_percent()
         self.memory_start = psutil.Process().memory_info()
@@ -147,7 +147,7 @@ class TestAPILatencyIsolation(SystemicPerformanceTest):
         models_to_test = ["gpt-4o-mini", "gpt-4o", "gpt-5"]
 
         for model in models_to_test:
-            with PerformanceProfiler(f"raw_api_{model}") as profiler:
+            with ProfilingContext(f"raw_api_{model}") as profiler:
                 try:
                     # Simple completion to measure pure API latency
                     completion = await client.chat.completions.create(
@@ -203,7 +203,7 @@ class TestAPILatencyIsolation(SystemicPerformanceTest):
         # Test with RefinerOutput schema (simplest agent schema)
         refiner_schema = RefinerOutput.model_json_schema()
 
-        with PerformanceProfiler("structured_api_refiner") as profiler:
+        with ProfilingContext("structured_api_refiner") as profiler:
             try:
                 completion = await client.beta.chat.completions.parse(
                     model="gpt-5",
@@ -260,7 +260,7 @@ class TestIntegrationLayerProfiling(SystemicPerformanceTest):
         """Measure LangChainService initialization time."""
 
         # Test traditional initialization (pre-pool)
-        with PerformanceProfiler("langchain_traditional_init") as profiler:
+        with ProfilingContext("langchain_traditional_init") as profiler:
             service = LangChainService(
                 model="gpt-4o-mini",
                 temperature=0.1,
@@ -274,7 +274,7 @@ class TestIntegrationLayerProfiling(SystemicPerformanceTest):
         self.record_performance("langchain_init", traditional_data)
 
         # Test pooled initialization
-        with PerformanceProfiler("langchain_pooled_init") as profiler:
+        with ProfilingContext("langchain_pooled_init") as profiler:
             service_pooled = LangChainService(
                 model=None,  # Let pool choose
                 agent_name="refiner",
@@ -302,7 +302,7 @@ class TestIntegrationLayerProfiling(SystemicPerformanceTest):
     async def test_model_discovery_overhead(self) -> None:
         """Measure model discovery service overhead."""
 
-        with PerformanceProfiler("model_discovery") as profiler:
+        with ProfilingContext("model_discovery") as profiler:
             discovery_service = ModelDiscoveryService(
                 enable_discovery=True, fallback_on_error=True
             )
@@ -338,7 +338,7 @@ class TestIntegrationLayerProfiling(SystemicPerformanceTest):
         ]
 
         for schema_name, schema_class in schemas_to_test:
-            with PerformanceProfiler(f"schema_prep_{schema_name}") as profiler:
+            with ProfilingContext(f"schema_prep_{schema_name}") as profiler:
                 service = LangChainService(
                     model="gpt-5", use_discovery=False, use_pool=False
                 )
@@ -396,7 +396,7 @@ class TestResourceBottleneckDetection(SystemicPerformanceTest):
         agents = ["refiner", "historian", "critic", "synthesis"]
 
         # Test sequential vs concurrent creation
-        with PerformanceProfiler("sequential_agent_creation") as profiler:
+        with ProfilingContext("sequential_agent_creation") as profiler:
             sequential_results = []
             for agent in agents:
                 result = await create_agent_service(agent)
@@ -415,7 +415,7 @@ class TestResourceBottleneckDetection(SystemicPerformanceTest):
         # Reset pool for fair comparison
         LLMServicePool.reset_instance()
 
-        with PerformanceProfiler("concurrent_agent_creation") as profiler:
+        with ProfilingContext("concurrent_agent_creation") as profiler:
             concurrent_results = await asyncio.gather(
                 *[create_agent_service(agent) for agent in agents],
                 return_exceptions=True,
@@ -499,7 +499,7 @@ class TestFallbackChainAnalysis(SystemicPerformanceTest):
         native_durations = []
 
         for i in range(native_attempts):
-            with PerformanceProfiler(f"native_attempt_{i}") as profiler:
+            with ProfilingContext(f"native_attempt_{i}") as profiler:
                 try:
                     # Force native method by mocking fallback
                     with patch.object(
@@ -522,7 +522,7 @@ class TestFallbackChainAnalysis(SystemicPerformanceTest):
         fallback_durations = []
 
         for i in range(fallback_attempts):
-            with PerformanceProfiler(f"fallback_attempt_{i}") as profiler:
+            with ProfilingContext(f"fallback_attempt_{i}") as profiler:
                 try:
                     # Force fallback by mocking native method
                     with patch.object(
@@ -598,7 +598,7 @@ class TestEndToEndPerformanceRegression(SystemicPerformanceTest):
         ]
 
         for i, test_case in enumerate(test_cases):
-            with PerformanceProfiler(f"refiner_baseline_{i}") as profiler:
+            with ProfilingContext(f"refiner_baseline_{i}") as profiler:
                 try:
                     result = await service.get_structured_output(
                         f"Refine this question: '{test_case}'. Provide a refined question and confidence score.",
@@ -643,7 +643,7 @@ class TestEndToEndPerformanceRegression(SystemicPerformanceTest):
         test_prompt = "Refine: 'What is AI?' Provide refined question and confidence."
 
         # Traditional approach (pre-pool)
-        with PerformanceProfiler("traditional_approach") as profiler:
+        with ProfilingContext("traditional_approach") as profiler:
             traditional_service = LangChainService(
                 model="gpt-5", agent_name="refiner", use_pool=False, use_discovery=False
             )
@@ -666,7 +666,7 @@ class TestEndToEndPerformanceRegression(SystemicPerformanceTest):
         LLMServicePool.reset_instance()
 
         # Pooled approach (current)
-        with PerformanceProfiler("pooled_approach") as profiler:
+        with ProfilingContext("pooled_approach") as profiler:
             pooled_service = LangChainService(
                 model=None,  # Let pool choose
                 agent_name="refiner",


### PR DESCRIPTION
## Summary
Roadmap **Phase 1.1 (structural debt)** — plus the version bump that #94 merged without.

The premise of 1.1 turned out to be **stale**: an independent AST scan verified the production namespace is already clean (**0 src-vs-src class-name collisions** across 468 classes), and the agent-output Pydantic-vs-TypedDict collisions it was scoped around were already resolved in #89 (`*Output` are Pydantic models, `*State` are the TypedDict state schemas). So this is **not** a mass renaming — it's a regression guardrail + one clarity rename + the deferred version bump.

## Changes
- **`scripts/check_class_conflicts.py`** — stdlib-only AST scanner; scans `src/` only and fails only on genuine production-namespace collisions. Test scaffolding (per-module mocks + pytest test-cases) and defensive import-fallback stubs legitimately reuse names, so they're intentionally ignored.
- **`.github/workflows/class-conflicts.yml`** — runs the check on push/PR (ratchet against regressions; green today).
- **Makefile** — `make check-class-conflicts`, wired into `make check`.
- **Rename** — the lone genuine test-helper name-reuse: `PerformanceProfiler` → `ProfilingContext` (a test-local context manager, contained to one file).
- **`pyproject.toml` 0.9.2 → 0.10.0** — feature 002 (#94) merged unversioned while tags had advanced to v0.9.3; minor bump for the new opt-in subsystem. This PR encompasses both.

## Verification
- `python scripts/check_class_conflicts.py` → green (468 classes, all unique).
- mypy clean on the script + the renamed test file; the renamed file still collects (10 tests).
- The 65 remaining registry "duplicates" are justified test scaffolding — documented, and ignored by the check.

## Note
After merge, tag **`v0.10.0`** so the tag matches `pyproject`.
