### PR TITLE
fix(docs): remove orphaned mike version provider (stale 0.9.3 on docs site)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -198,8 +198,6 @@ extra:
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/aucontraire/cognivault
-  version:
-    provider: mike
   analytics:
     feedback:
       title: Was this page helpful?


### PR DESCRIPTION
## Summary
Fixes the docs site showing a stale version (`0.9.3`) at https://aucontraire.github.io/cognivault/.

## Root cause
`mkdocs.yml` set `extra.version.provider: mike`, which renders mkdocs-material's version *selector* (loaded from `versions.json` via JS). But the docs workflow only runs `mkdocs build --strict` + a Pages-artifact deploy — it **never runs `mike deploy`**. So the selector was orphaned: decoupled from `pyproject`/tags/releases and stuck at whatever it last showed. The version bump to `0.10.0`, the `v0.10.0` tag, and the GitHub release don't (and can't) touch it. The live site's actual content is current; only the version dropdown was stale (and browser-cached).

## Fix
Remove `extra.version.provider: mike`. The stale/broken selector disappears; the site otherwise builds identically (verified with `mkdocs build --strict`). Since `mike` was never deployed, there's no versioned-docs history to lose.

*(A proper versioned-docs switcher would instead wire `mike deploy` into the release workflow — a larger reconfiguration, deliberately not done here.)*
